### PR TITLE
feat: read baseUrl from an environment variable

### DIFF
--- a/src/raphael_frontend_react/src/App.js
+++ b/src/raphael_frontend_react/src/App.js
@@ -2,7 +2,7 @@ import './App.css';
 import { useState } from "react";
 
 const conf = {
-  baseUrl: 'https://raphael.fullfact.org/api',
+  baseUrl: process.env.REACT_APP_BASE_URL || 'https://raphael.fullfact.org/api',
   defaultHeaders: {
     Accept: "application/json",
     "Content-Type": "application/json;charset=UTF-8"


### PR DESCRIPTION
Fixes #40.

You can use this by starting the development server with:
```
REACT_APP_BASE_URL=http://localhost:3000/api npm run start
```

…or with a .env file.

-----------------

## Pull request checklist

- [x] I have linked my PR to an issue
- [x] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [x] My branch is up-to-date with `main`
- [ ] Where appropriate, I have added or updated tests
- [ ] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
