### PR TITLE
build: install node dependencies with `npm ci`

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -3,7 +3,7 @@ FROM node:18.2-alpine AS builder
 WORKDIR /app
 COPY src/raphael_frontend_react/package*.json ./
 
-RUN npm install --omit=dev
+RUN npm ci
 
 COPY src/raphael_frontend_react/ ./
 RUN npm run build


### PR DESCRIPTION
`npm ci` installs from the lockfile. `npm install` installs from package.json, and updates the lockfile. I guess in the dockerfile, we want to do the former.

-----------------

## Pull request checklist

- [ ] ~I have linked my PR to an issue~
- [x] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [x] My branch is up-to-date with `main`
- [ ] Where appropriate, I have added or updated tests
- [ ] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
