### PR TITLE
fix: increase timeout from 30 seconds (default) to 30 minutes

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -18,4 +18,4 @@ EXPOSE 3000
 ENV FLASK_APP=app.py
 ENV FLASK_ENV=production
 ENV DB_PATH=/app/data/database.db
-CMD ["gunicorn", "-b", "0.0.0.0:3000", "-w", "2", "raphael_backend_flask.app:app"]
+CMD ["gunicorn", "-b", "0.0.0.0:3000", "-w", "2", "-t", "1800", "raphael_backend_flask.app:app"]

--- a/ansible/playbooks/nginx_docker.yaml
+++ b/ansible/playbooks/nginx_docker.yaml
@@ -71,6 +71,10 @@
 
               location ~ ^/api {
                   proxy_pass http://127.0.0.1:3000;
+                  proxy_read_timeout 1800;
+                  proxy_connect_timeout 1800;
+                  proxy_send_timeout 1800;
+                  send_timeout 1800;
               }
 
               location / {


### PR DESCRIPTION
Fixes #53

It's not 100% clear that this will fix the issue, however in my testing, the request is failing a few ms longer than 30s, and gunicorn has [a default timeout of 30s for a request](https://docs.gunicorn.org/en/stable/settings.html#timeout), so at the very least this looks to be part of the issue. I've also increased the various nginx timeouts which tend to default to 60s.

-----------------

## Pull request checklist

- [X] I have linked my PR to an issue
- [X] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [X] My branch is up-to-date with `main`
- [ ] ~Where appropriate, I have added or updated tests~
- [ ] ~Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes~
