### PR TITLE
56 chunks of youtube transcripts should include their timestamp offsets

### DIFF
--- a/src/health_misinfo_shared/vertex.py
+++ b/src/health_misinfo_shared/vertex.py
@@ -56,13 +56,15 @@ def process_video(transcript: dict) -> list[dict]:
     llm_responses = []
 
     chunks = youtube_api.form_chunks(transcript)
-    for _id, (chunk_text, chunk_offset) in enumerate(chunks):
+    for _id, chunk in enumerate(chunks):
         try:
-            llm_response = generate_reponse(chunk_text)
+            llm_response = generate_reponse(chunk["text"])
             for found_claim in llm_response:
                 found_claim["video_id"] = video_id
-                found_claim["chunk"] = chunk_text
-                found_claim["offset_s"] = chunk_offset
+                found_claim["chunk"] = chunk["text"]
+                found_claim["offset_s"] = chunk["start_offset"]
+                found_claim["offset_end_s"] = chunk["end_offset"]
+                print(found_claim)
                 llm_responses.append(found_claim)
         except Exception as e:
             # just carry on for now...

--- a/src/health_misinfo_shared/vertex.py
+++ b/src/health_misinfo_shared/vertex.py
@@ -56,12 +56,13 @@ def process_video(transcript: dict) -> list[dict]:
     llm_responses = []
 
     chunks = youtube_api.form_chunks(transcript)
-    for _id, chunk in enumerate(chunks):
+    for _id, (chunk_text, chunk_offset) in enumerate(chunks):
         try:
-            llm_response = generate_reponse(chunk)
+            llm_response = generate_reponse(chunk_text)
             for found_claim in llm_response:
                 found_claim["video_id"] = video_id
-                found_claim["chunk"] = chunk
+                found_claim["chunk"] = chunk_text
+                found_claim["offset_s"] = chunk_offset
                 llm_responses.append(found_claim)
         except Exception as e:
             # just carry on for now...
@@ -108,4 +109,8 @@ if __name__ == "__main__":
         "prostate_cancer_nat_rem",
         "weight_loss_nat_rem",
     ]
-    generate_training_set(_folders, label="natural_remedies_x5")
+    # generate_training_set(_folders, label="natural_remedies_x5")
+    all_videos_in_folder = youtube_api.load_texts(_folders[0])
+    for video in all_videos_in_folder:
+        process_video(video)
+        wibble

--- a/src/health_misinfo_shared/youtube_api.py
+++ b/src/health_misinfo_shared/youtube_api.py
@@ -104,18 +104,21 @@ def load_texts(folder) -> list[dict]:
     return flat_list
 
 
-def form_chunks(transcript_obj: dict) -> Iterator[str]:
-    """Split/merged a list of sentences into series of overlapping text chunks."""
+def form_chunks(transcript_obj: dict) -> Iterator[tuple[str, float]]:
+    """Split/merged a list of sentences into series of overlapping text chunks.
+    Also offset of start of chunk"""
     current_chunk_text = ""
+    current_chunk_offset = 0.0
     for s in transcript_obj:
         current_chunk_text += s["sentence_text"] + " "
         if len(current_chunk_text) > 5000:
-            yield current_chunk_text
+            yield current_chunk_text, current_chunk_offset
             # Keep the end of this chunk as the start of the next...
             current_chunk_text = current_chunk_text[-500:]
             # ...but remove the first (probably incomplete) word
             current_chunk_text[current_chunk_text.index(" ") :].strip()
-    yield current_chunk_text
+            current_chunk_offset = s["start"]
+    yield current_chunk_text, current_chunk_offset
 
 
 def download_captions(
@@ -130,6 +133,7 @@ def download_captions(
     already_exists = len(existing_captions.get("sentences", [])) > 0
     if not already_exists:
         captions = get_captions(video_id, video_title=video_title, query=query)
+        # captions['sentences'] is a list of dicts {"start": <offset, seconds>, "sentence_text": <text>}
         if captions:
             target_dir = f"data/captions/{folder}"
             Path(target_dir).mkdir(parents=True, exist_ok=True)
@@ -298,5 +302,7 @@ def multi_issue_search():
 
 
 if __name__ == "__main__":
-    multi_issue_search()
-    print()
+    # multi_issue_search()
+    # print()
+
+    download_captions("o9AEPKn4MMI", "dc_test_timestamp")


### PR DESCRIPTION
Fixes #56.

Copy start + end offset, in seconds
from individual sentences 
to chunks of text
so a link to the relevant bit of video/transcript can be added after processing by the LLM

-----------------

## Pull request checklist

- [x] I have linked my PR to an issue
- [ ] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [x] My branch is up-to-date with `main`
- [ ] Where appropriate, I have added or updated tests
- [ ] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
