### PR TITLE
73-write-an-evaluation-script-using-promptfoo

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -1,0 +1,46 @@
+# Evaluation
+
+This directory contains code for evaluating our prompts using promptfoo.
+
+## How to run evaluation
+
+1. Check `promptfooconfig.yaml` and check that it's referring to the prompts and tests you want to run.
+Tests are found in `tests.csv` by default, and prompts in the specified test files.
+For comparing context vs no context, I wrote a file (`comparing_prompt_with_and_without_context.py`) which generates the prompt files and the tests for that specific case.
+2. Make sure you're inside the evaluation directory and run the following. This will run the evaluation, and generate your results.
+When it finishes, a nice colourful table will be printed in your terminal.
+
+        npx promptfoo@latest eval
+
+3. Run the following to view the results in your browser.
+
+        npx promptfoo@latest view
+
+
+## How to make a new assertion/test
+When we define our test cases, we specify what assertions we want to apply.
+
+Each assertion gives a pass/fail, and they can be simple things like "contains this substring" or "is in json format", or they can be more complicated, like asking an LLM if the output is a certain way.
+
+We can also give a custom python script as an assertion.
+This script must have a `get_assert` function, and be in the expected format promptfoo wants.
+Here's an example:
+
+```python
+from typing import Dict, TypedDict, Union
+
+def get_assert(output: str, context) -> Union[bool, float, Dict[str, Any]]:
+    print('Prompt:', context['prompt'])
+    print('Vars', context['vars']['topic'])
+
+    # This return is an example GradingResult dict
+    return {
+      'pass': True,
+      'score': 0.6,
+      'reason': 'Looks good to me',
+    }
+```
+
+So for each new way to compare output to evaluation data, you'll want a file like this.
+
+Remember to put it in an `__evaluationN` column in your `tests.csv` file.

--- a/evaluation/assert_evaluation_metrics.py
+++ b/evaluation/assert_evaluation_metrics.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+
+def get_assert(output: str, context: dict[str, Any]) -> bool | float | dict[str, Any]:
+    prompt = context["prompt"]
+    variables = context["vars"]
+
+    # This return is an example GradingResult dict
+    return {
+        "pass": True,
+        "score": 0.9,
+        "reason": "That's some good evaluation (test)",
+    }

--- a/evaluation/assert_quotes_contained_in_chunk.py
+++ b/evaluation/assert_quotes_contained_in_chunk.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+
+def get_assert(output: str, context: dict[str, Any]) -> bool | float | dict[str, Any]:
+    prompt = context["prompt"]
+    variables = context["vars"]
+
+    # This return is an example GradingResult dict
+    return {
+        "pass": True,
+        "score": 0.9,
+        "reason": "Quotes are all contained in chunk (test)",
+    }

--- a/evaluation/comparing_prompt_with_and_without_context.py
+++ b/evaluation/comparing_prompt_with_and_without_context.py
@@ -1,0 +1,73 @@
+import json
+import pandas as pd
+
+from health_misinfo_shared.prompts import HEALTH_INFER_MULTI_LABEL_PROMPT
+from health_misinfo_shared.fine_tuning import construct_in_context_examples
+
+
+in_context_examples, eval_examples = construct_in_context_examples(
+    [
+        "data/MVP_labelled_claims_1.csv",
+        "data/MVP_labelled_claims_2.csv",
+        "data/MVP_labelled_claims_3.csv",
+        "data/MVP_labelled_claims_4.csv",
+    ]
+)
+
+
+def make_prompts_files():
+    base_prompt = HEALTH_INFER_MULTI_LABEL_PROMPT
+
+    in_context_prompt_part = (
+        "\nHere are some examples to learn from:\n" + in_context_examples
+    )
+
+    input_text = "```{{chunk}}```"
+
+    prompt_no_context = "\n".join([base_prompt, input_text])
+    prompt_with_context = "\n".join([base_prompt, in_context_prompt_part, input_text])
+
+    with open("evaluation/prompt_no_context.txt", "w") as out_file:
+        out_file.write(prompt_no_context)
+
+    with open("evaluation/prompt_with_context.txt", "w") as out_file:
+        out_file.write(prompt_with_context)
+
+
+def make_tests_file():
+    training_data_file = "data/training_set_v2.csv"
+    training_data = pd.read_csv(training_data_file)
+
+    # generate the test rows
+    eval_data = (
+        training_data.groupby("chunk")
+        .apply(
+            lambda sub_df: [
+                json.dumps(
+                    {"claim": row["claim"], "explanation": row["explanation"]}, indent=4
+                )
+                for idx, row in sub_df.iterrows()
+            ]
+        )
+        .reset_index()
+    )
+    eval_data.columns = ["chunk", "expected_output"]
+
+    # add the assertions
+    eval_data["__expected1"] = ["is-json"] * eval_data.shape[0]
+    eval_data["__expected2"] = [
+        "python:file://assert_quotes_contained_in_chunk.py"
+    ] * eval_data.shape[0]
+    eval_data["__expected3"] = [
+        "python:file://assert_evaluation_metrics.py"
+    ] * eval_data.shape[0]
+
+    eval_data.to_csv("evaluation/tests.csv")
+
+
+if __name__ == "__main__":
+    # make a txt file for each prompt
+    make_prompts_files()
+
+    # make a tests.csv file with input and expected output for each test
+    make_tests_file()

--- a/evaluation/evaluation.py
+++ b/evaluation/evaluation.py
@@ -1,0 +1,190 @@
+import json
+import time
+from typing import Any
+from dataclasses import dataclass
+
+import vertexai
+import vertexai.preview.generative_models as generative_models
+
+from google.auth import default
+from vertexai.generative_models import GenerativeModel
+
+
+credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+
+GCP_PROJECT_ID = "exemplary-cycle-195718"
+GCP_LLM_LOCATION = "us-east1"  # NB: Gemini is not available in europe-west2 (yet?)
+CURRENT_MODEL = "gemini-1.5-pro-preview-0514"
+
+
+class ProcessingException(Exception):
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+
+
+class ParsingException(Exception):
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+
+
+@dataclass(frozen=True)
+class ProviderOptions:
+    id: str | None
+    config: dict[str, Any] | None
+
+    @staticmethod
+    def from_dict(dictionary: dict[str, Any]) -> "ProviderOptions":
+        return ProviderOptions(
+            id=dictionary.get("id", None),
+            config=dictionary.get("config", {}),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"id": self.id, "config": self.config}
+
+
+@dataclass(frozen=True)
+class CallApiContextParams:
+    vars: dict[str, str]
+
+    @staticmethod
+    def from_dict(dictionary: dict[str, Any]) -> "CallApiContextParams":
+        return CallApiContextParams(vars=dictionary["vars"])
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"vars": self.vars}
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    total: int
+    prompt: int
+    completion: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total": self.total,
+            "prompt": self.prompt,
+            "completion": self.completion,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderResponse:
+    output: str | dict[str, Any] | None = None
+    error: str | None = None
+    tokenUsage: TokenUsage | None = None
+    cost: float | None = None
+    cached: bool | None = None
+    logProbs: list[float] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "output": self.output,
+            "error": self.error,
+            "tokenUsage": (
+                self.tokenUsage.to_dict() if self.tokenUsage is not None else None
+            ),
+            "cost": self.cost,
+            "cached": self.cached,
+            "logProbs": self.logProbs,
+        }
+
+
+def load_model() -> GenerativeModel:
+    vertexai.init(project=GCP_PROJECT_ID, location=GCP_LLM_LOCATION)
+    return GenerativeModel(model_name=CURRENT_MODEL)
+
+
+def parse_model_json_output(model_output: str) -> list[dict[str, str]]:
+    model_output = model_output.strip()
+    if model_output.startswith("[") and model_output.endswith("]"):
+        return json.loads(model_output)
+
+    first_square_bracket_idx = model_output.find("[")
+    last_square_bracket_idx = model_output.rfind("]")
+    if first_square_bracket_idx > 0 and last_square_bracket_idx > 0:
+        return json.loads(
+            model_output[first_square_bracket_idx : last_square_bracket_idx + 1]
+        )
+    raise Exception("Could not parse the string.")
+
+
+def run_prompt(model: GenerativeModel, prompt: str) -> str:
+    parameters = {
+        "candidate_count": 1,
+        "max_output_tokens": 8192,
+        "temperature": 0,
+        "top_p": 1,
+    }
+    safety_settings = {
+        generative_models.HarmCategory.HARM_CATEGORY_HATE_SPEECH: generative_models.HarmBlockThreshold.BLOCK_ONLY_HIGH,
+        generative_models.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: generative_models.HarmBlockThreshold.BLOCK_ONLY_HIGH,
+        generative_models.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT: generative_models.HarmBlockThreshold.BLOCK_ONLY_HIGH,
+        generative_models.HarmCategory.HARM_CATEGORY_HARASSMENT: generative_models.HarmBlockThreshold.BLOCK_ONLY_HIGH,
+    }
+    try:
+        response = model.generate_content(
+            prompt,
+            generation_config=parameters,
+            safety_settings=safety_settings,
+        )
+    except Exception as e:
+        raise ProcessingException(
+            f"Error while running prompt. Original error: {repr(e)}"
+        )
+
+    try:
+        candidate = response.candidates[0]
+        return candidate.text
+    except Exception as e:
+        raise ParsingException(
+            f"Could not handle output. It is not in correct json format. Original error: {repr(e)}"
+        )
+
+
+def call_api(
+    prompt: str, options: dict[str, Any], context: dict[str, Any]
+) -> dict[str, Any]:
+    parsed_options: ProviderOptions = ProviderOptions.from_dict(options)
+    parsed_context: CallApiContextParams = CallApiContextParams.from_dict(context)
+
+    config: dict[str, Any] = parsed_options.config
+    additional_option: dict[str, Any] = config.get("additionalOption", None)
+
+    # persona = parsed_context.vars.get("persona", None)
+    chunk = parsed_context.vars.get("chunk", None)
+    print(f"Prompt: {prompt[:500]}", end="\n\n")
+    # print(f"Persona: {persona}\nText Preview: {text[:500]}")
+
+    model: GenerativeModel = load_model()
+    print("Loaded model")
+
+    try:
+        output: str = run_prompt(model, prompt)
+        response = ProviderResponse(output=output, error=None, tokenUsage=None)
+    except Exception as e:
+        response = ProviderResponse(output=None, error=repr(e), tokenUsage=None)
+
+    print("Successfully made a response.")
+    time.sleep(2)  # just wait a couple of seconds so we don't meet quotas
+    return response.to_dict()
+
+
+if __name__ == "__main__":
+    persona = "doctor"
+    text = """
+    There are 3 valves inside the heart. The biggest is the aorta. This is the main part that can go wrong.
+    """
+    result = call_api(
+        prompt=f"You are a {persona}. Give me a raw json encoded list of health claims in the following text: {text}",
+        options={},
+        context={
+            "vars": {
+                "persona": persona,
+                "text": text,
+            }
+        },
+    )
+
+    print(result)

--- a/evaluation/promptfooconfig.yaml
+++ b/evaluation/promptfooconfig.yaml
@@ -1,6 +1,9 @@
-# This configuration compares LLM output of 2 prompts x 2 GPT models across 3 test cases.
+# This generic configuration which uses the python script evaluation.py as it's LLM.
+# Prompts are taken from the specified text files.
+# Tests are taken from tests.csv
+# Instructions in the readme.
 # Learn more: https://promptfoo.dev/docs/configuration/guide
-description: 'Health Prompt Eval'
+description: 'Raphael Eval'
 
 prompts:
   - file://prompt_no_context.txt
@@ -8,7 +11,7 @@ prompts:
 
 providers:
   - id: 'python:evaluation.py'
-    label: 'Test script 1'   # Optional display label for this provider
+    label: 'Python Gemini Script'   # Optional display label for this provider
     # config:
     #   pythonExecutable: *can set the python executable if you want, but I've just been making sure I'm in the right venv.*
 

--- a/evaluation/promptfooconfig.yaml
+++ b/evaluation/promptfooconfig.yaml
@@ -1,0 +1,15 @@
+# This configuration compares LLM output of 2 prompts x 2 GPT models across 3 test cases.
+# Learn more: https://promptfoo.dev/docs/configuration/guide
+description: 'Health Prompt Eval'
+
+prompts:
+  - file://prompt_no_context.txt
+  - file://prompt_with_context.txt
+
+providers:
+  - id: 'python:evaluation.py'
+    label: 'Test script 1'   # Optional display label for this provider
+    # config:
+    #   pythonExecutable: *can set the python executable if you want, but I've just been making sure I'm in the right venv.*
+
+tests: tests.csv


### PR DESCRIPTION
Fixes #73 .

Adds some basic files which allow us to compare prompts with promptfoo in a realistic environment.

The example used was comparing prompts with and without context.

The tests themselves (i.e. the means of comparing) have not been implemented as part of this PR. They are to come in future updates (#80 #81 ).

But the generic scripts here mean we now just have to write the individual functionalities for each test and they can slot in.

-----------------

## Pull request checklist

- [x] I have linked my PR to an issue
- [x] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [x] My branch is up-to-date with `main`
- [x] Where appropriate, I have added or updated tests
- [x] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
