### PR TITLE
95 Ask for a direct quote as well as a paraphrase in multi label prompt

### DIFF
--- a/evaluation/evaluation.py
+++ b/evaluation/evaluation.py
@@ -172,16 +172,16 @@ def call_api(
 
 
 if __name__ == "__main__":
-    persona = "doctor"
+    from health_misinfo_shared.prompts import HEALTH_INFER_MULTI_LABEL_PROMPT
+
     text = """
     There are 3 valves inside the heart. The biggest is the aorta. This is the main part that can go wrong.
     """
     result = call_api(
-        prompt=f"You are a {persona}. Give me a raw json encoded list of health claims in the following text: {text}",
+        prompt=f"{HEALTH_INFER_MULTI_LABEL_PROMPT}\n\n{text}",
         options={},
         context={
             "vars": {
-                "persona": persona,
                 "text": text,
             }
         },

--- a/src/health_misinfo_shared/prompts.py
+++ b/src/health_misinfo_shared/prompts.py
@@ -151,7 +151,8 @@ HEALTH_TRAINING_MULTI_LABEL_PROMPT = """
             4 - Return a list of JSON format output as follows:
                         [
                             {
-                                "claim": <claim being made in the sentence>,
+                                "claim": <claim being made in the sentence. You can reword it slightly to make it make sense without context, but do not change the meaning of the claim in doing so.>,
+                                "original_text": <the original sentence, exactly as it appears in the input, containing the claim>,
                                 "labels":
                                     {
                                         "understandability": <one of these labels: "understandable", "not understandable">,
@@ -230,7 +231,8 @@ HEALTH_INFER_MULTI_LABEL_PROMPT = """
             5 - Return a list of JSON format output as follows:
                         [
                             {
-                                "claim": <claim being made in the sentence>,
+                                "claim": <claim being made in the sentence. You can reword it slightly to make it make sense without context, but do not change the meaning of the claim in doing so.>,
+                                "original_text": <the original sentence, exactly as it appears in the input, containing the claim>,
                                 "labels":
                                     {
                                         "understandability": <one of these labels: "understandable", "not understandable">,


### PR DESCRIPTION
Fixes #95.

Updates the prompt so it gives a paraphrase of the claim alongside the direct quote.

The paraphrased version is the "claim", and the quote goes in a field called "original_text".

-----------------

## Pull request checklist

- [ ] I have linked my PR to an issue
- [ ] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [ ] My branch is up-to-date with `main`
- [ ] Where appropriate, I have added or updated tests
- [ ] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
