### PR TITLE
Evaluation test for checking if the quote appears in the chunk

### DIFF
--- a/evaluation/assert_quotes_contained_in_chunk.py
+++ b/evaluation/assert_quotes_contained_in_chunk.py
@@ -1,13 +1,107 @@
+import re
+import json
 from typing import Any
+from pprint import pformat, pp
+
+
+def check_quote_in_chunk(quote: str, chunk: str) -> bool:
+    not_alphanum_pattern = re.compile(r"[^a-zA-Z0-9 ]")
+    stripped_quote = not_alphanum_pattern.sub("", quote).strip().lower()
+    stripped_chunk = not_alphanum_pattern.sub("", chunk).strip().lower()
+    return stripped_quote in stripped_chunk
+
+
+def make_reason(
+    claims: list[dict[str, Any]], passes_list: list[bool], chunk: str
+) -> str:
+    quotes_not_contained = [
+        claim["original_text"]
+        for claim, does_pass in zip(claims, passes_list)
+        if not does_pass
+    ]
+
+    return f"""
+    The following quotes:
+    {pformat(quotes_not_contained)}
+    Are not contained in the chunk:
+    {chunk}
+    """
 
 
 def get_assert(output: str, context: dict[str, Any]) -> bool | float | dict[str, Any]:
-    prompt = context["prompt"]
     variables = context["vars"]
+
+    generated_output = json.loads(output)
+
+    quote_in_chunk = [
+        check_quote_in_chunk(claim["original_text"], variables["text"])
+        for claim in generated_output
+    ]
+
+    score = sum(quote_in_chunk) / len(quote_in_chunk)
+    passes = all(quote_in_chunk)
 
     # This return is an example GradingResult dict
     return {
-        "pass": True,
-        "score": 0.9,
-        "reason": "Quotes are all contained in chunk (test)",
+        "pass": passes,
+        "score": score,
+        "reason": (
+            "Quotes are all contained in chunk"
+            if passes
+            else make_reason(generated_output, quote_in_chunk, variables["text"])
+        ),
     }
+
+
+if __name__ == "__main__":
+    test_generated_output = """
+    [
+        {
+            "claim": "The sky is blue.",
+            "original_text": "As we all know, it is blue",
+            "labels":
+                {
+                    "understandability": "understandable",
+                    "type_of_claim": "statement of fact",
+                    "type_of_medical_claim": "not medical",
+                    "support": "uncontroversial statement",
+                    "harm": "harmless",
+                    "summary": "not worth checking"
+                }
+        },
+        {
+            "claim": "Eating walnuts will make you live longer",
+            "original_text": "Eating walnuts will make you live longer",
+            "labels":
+                {
+                    "understandability": "understandable",
+                    "type_of_claim": "statement of fact",
+                    "type_of_medical_claim": "cause/effect",
+                    "support": "novel claim",
+                    "harm": "low harm",
+                    "summary": "may be worth checking"
+                }
+        }
+    ]
+    """.strip()
+
+    positive_test_chunk = "We all love the sky. And as we all know, it is blue. Eating walnuts will make you live longer."
+    negative_test_chunk = "This has none of those claims"
+
+    output = get_assert(
+        test_generated_output,
+        context={
+            "prompt": "PROMPT",
+            "vars": {"text": positive_test_chunk},
+        },
+    )
+    pp(output)
+    print()
+    output = get_assert(
+        test_generated_output,
+        context={
+            "prompt": "PROMPT",
+            "vars": {"text": negative_test_chunk},
+        },
+    )
+    pp(output)


### PR DESCRIPTION
Fixes #80 .

We want to check if the quotes pulled out by the model actually appear directly in the chunk text given to the LLM as input.

This test will check that (and will be run by promptfoo)

-----------------

## Pull request checklist

- [ ] I have linked my PR to an issue
- [ ] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [ ] My branch is up-to-date with `main`
- [ ] Where appropriate, I have added or updated tests
- [ ] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
