### PR TITLE
116 improve json parsing of generated output

### DIFF
--- a/src/health_misinfo_shared/data_parsing.py
+++ b/src/health_misinfo_shared/data_parsing.py
@@ -1,20 +1,33 @@
 import re
 import ast
 import json
+from typing import Any
+
+
+def parse_json_string(json_string: str) -> dict[str, Any] | None:
+    try:
+        return json.loads(json_string)
+    except json.JSONDecodeError:
+        try:
+            return ast.literal_eval(json_string)
+        except Exception as e:
+            return None
 
 
 def parse_model_json_output(model_output: str) -> list[dict[str, str]]:
     original_output = model_output
-    model_output = re.sub(r"```", "", model_output.strip()).rstrip("\n").lstrip("json")
-    if model_output.startswith("[") and model_output.endswith("]"):
-        return json.loads(ast.literal_eval(model_output))
+    model_output = model_output.strip()
+    # model_output = re.sub(r"```", "", model_output.strip()).rstrip("\n").lstrip("json")
+    try:
+        if model_output.startswith("[") and model_output.endswith("]"):
+            return parse_json_string(model_output)
 
-    first_square_bracket_idx = model_output.find("[")
-    last_square_bracket_idx = model_output.rfind("]")
-    if first_square_bracket_idx > 0 and last_square_bracket_idx > 0:
-        return json.loads(
-            ast.literal_eval(
+        first_square_bracket_idx = model_output.find("[")
+        last_square_bracket_idx = model_output.rfind("]")
+        if first_square_bracket_idx >= 0 and last_square_bracket_idx >= 0:
+            return parse_json_string(
                 model_output[first_square_bracket_idx : last_square_bracket_idx + 1]
             )
-        )
+    except Exception as e:
+        pass
     raise Exception("Could not parse the string: ", model_output, original_output)

--- a/src/health_misinfo_shared/data_parsing.py
+++ b/src/health_misinfo_shared/data_parsing.py
@@ -1,0 +1,20 @@
+import re
+import ast
+import json
+
+
+def parse_model_json_output(model_output: str) -> list[dict[str, str]]:
+    original_output = model_output
+    model_output = re.sub(r"```", "", model_output.strip()).rstrip("\n").lstrip("json")
+    if model_output.startswith("[") and model_output.endswith("]"):
+        return json.loads(ast.literal_eval(model_output))
+
+    first_square_bracket_idx = model_output.find("[")
+    last_square_bracket_idx = model_output.rfind("]")
+    if first_square_bracket_idx > 0 and last_square_bracket_idx > 0:
+        return json.loads(
+            ast.literal_eval(
+                model_output[first_square_bracket_idx : last_square_bracket_idx + 1]
+            )
+        )
+    raise Exception("Could not parse the string: ", model_output, original_output)

--- a/src/health_misinfo_shared/find_claims_within_captions.py
+++ b/src/health_misinfo_shared/find_claims_within_captions.py
@@ -10,6 +10,7 @@ from vertexai.language_models import TextGenerationModel
 from vertexai.generative_models import GenerativeModel, Part
 
 from health_misinfo_shared.prompts import TRAINING_SET_HEALTH_CLAIMS_PROMPT
+from health_misinfo_shared.data_parsing import parse_model_json_output
 
 
 credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
@@ -61,20 +62,6 @@ def loop_through_videos(video_caption_directory: str) -> Iterator[str]:
 def load_model() -> GenerativeModel:
     vertexai.init(project=GCP_PROJECT_ID, location=GCP_LLM_LOCATION)
     return GenerativeModel(model_name=CURRENT_MODEL)
-
-
-def parse_model_json_output(model_output: str) -> list[dict[str, str]]:
-    model_output = model_output.strip()
-    if model_output.startswith("[") and model_output.endswith("]"):
-        return json.loads(model_output)
-
-    first_square_bracket_idx = model_output.find("[")
-    last_square_bracket_idx = model_output.rfind("]")
-    if first_square_bracket_idx > 0 and last_square_bracket_idx > 0:
-        return json.loads(
-            model_output[first_square_bracket_idx : last_square_bracket_idx + 1]
-        )
-    raise Exception("Could not parse the string.")
 
 
 def print_info(video_id: str, input_str: str, output_str: str) -> None:

--- a/tests/health_misinfo_shared/test_data_parsing.py
+++ b/tests/health_misinfo_shared/test_data_parsing.py
@@ -1,0 +1,126 @@
+from pytest import mark, param
+from health_misinfo_shared.data_parsing import parse_model_json_output
+
+
+@mark.parametrize(
+    "model_output,expected,should_fail",
+    [
+        param(
+            """
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"}
+            ]
+            """,
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"},
+            ],
+            False,
+            id="perfect case",
+        ),
+        param(
+            """
+            json```
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"}
+            ]```
+            """,
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"},
+            ],
+            False,
+            id="prefixed with json, surrounded by backticks",
+        ),
+        param(
+            """
+            json```
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"}
+            ]
+            """,
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"},
+            ],
+            False,
+            id="missing final backticks",
+        ),
+        param(
+            """
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"}
+            ]```
+            """,
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"},
+            ],
+            False,
+            id="only backticks at the end",
+        ),
+        param(
+            """
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"}
+            """,
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"},
+            ],
+            True,
+            id="missing closing brace",
+        ),
+        param(
+            """
+                {"claim": "claim 1"},
+                {"claim": "claim 2"}
+            ]
+            """,
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"},
+            ],
+            True,
+            id="missing opening brace",
+        ),
+        param(
+            """
+            Claim: Claim 1
+            Claim: Claim 2
+            """,
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"},
+            ],
+            True,
+            id="not json",
+        ),
+        param(
+            """
+            [
+                {'claim': 'claim 1'},
+                {'claim': 'claim 2'}
+            ]
+            """,
+            [
+                {"claim": "claim 1"},
+                {"claim": "claim 2"},
+            ],
+            False,
+            id="single quotes",
+        ),
+    ],
+)
+def test_parse_model_json_output(
+    model_output: str, expected: list[dict[str, str]], should_fail: bool
+):
+    try:
+        assert parse_model_json_output(model_output) == expected and not should_fail
+    except Exception:
+        assert should_fail


### PR DESCRIPTION
Fixes #116 .

Improves the JSON parsing, notably fixing a couple of noted bugs:

* crash on end (but not front) backticks
* crash on single quotes in dict (as opposed to double)

It now falls back to trying to read the string as a python dictionary if json reading fails. If this is a bad idea, do say.

-----------------

## Pull request checklist

- [x] I have linked my PR to an issue
- [x] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [x] My branch is up-to-date with `main`
- [x] Where appropriate, I have added or updated tests
- [x] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
