### PR TITLE
fix: remove text from labels

### DIFF
--- a/src/raphael_backend_flask/templates/video_analysis.html
+++ b/src/raphael_backend_flask/templates/video_analysis.html
@@ -147,10 +147,8 @@
         href="https://www.youtube.com/watch?v={{ youtube_id }}&t={{ claim['offset_start_s'] }}s"
         >
           <strong>{{ loop.index }}.</strong>
-          {% if claim['labels']['summary'] == 'worth checking' %}
-          <span class="badge badge-danger">{{ claim['labels']['summary'] }}</span>
-          {% elif claim['labels']['summary'] == 'may be worth checking' %}
-          <span class="badge badge-warning">{{ claim['labels']['summary'] }}</span>
+          {% if checkworthiness == 'danger' or checkworthiness == 'warning' %}
+          <span class="badge badge-{{ checkworthiness }}">&nbsp;</span>
           {% endif %}
 
           {{ claim['claim'] }}


### PR DESCRIPTION
Fixes #124.

I’ve just removed the text from the labels, rather than reverting this completely. Reverting it is a bit more difficult now that the colour highlighting is used for more things.

Here’s how this looks:

---

<img width="727" alt="Screenshot 2024-06-13 at 13 09 24" src="https://github.com/FullFact/health-misinfo-shared/assets/464193/c390af0a-f830-4804-81a9-8df5cacfceea">

---

When you click a claim, it highlights using the label colour.

-----------------

## Pull request checklist

- [x] I have linked my PR to an issue
- [x] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [x] My branch is up-to-date with `main`
- [ ] Where appropriate, I have added or updated tests
- [ ] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
