### PR TITLE
fix: only call google.auth.default() from inside a function

### DIFF
--- a/dev/prompt_evaluation/ed_autosxs_tests.py
+++ b/dev/prompt_evaluation/ed_autosxs_tests.py
@@ -2,10 +2,6 @@ import os
 import pandas as pd
 from google.cloud import aiplatform
 
-from google.auth import default
-
-
-credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
 GCP_PROJECT_NUMBER = 1447178727

--- a/dev/prompt_evaluation/ed_promptfoo_tests.py
+++ b/dev/prompt_evaluation/ed_promptfoo_tests.py
@@ -3,11 +3,8 @@ from typing import Any
 from dataclasses import dataclass
 
 import vertexai
-from google.auth import default
 from vertexai.generative_models import GenerativeModel
 
-
-credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
 GCP_LLM_LOCATION = "us-east1"  # NB: Gemini is not available in europe-west2 (yet?)

--- a/evaluation/evaluation.py
+++ b/evaluation/evaluation.py
@@ -8,13 +8,10 @@ from dataclasses import dataclass
 import vertexai
 import vertexai.preview.generative_models as generative_models
 
-from google.auth import default
 from vertexai.generative_models import GenerativeModel
 
 from health_misinfo_shared.data_parsing import parse_model_json_output
 
-
-credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
 GCP_LLM_LOCATION = "us-east1"  # NB: Gemini is not available in europe-west2 (yet?)

--- a/src/health_misinfo_shared/find_claims_within_captions.py
+++ b/src/health_misinfo_shared/find_claims_within_captions.py
@@ -3,8 +3,6 @@ import json
 import time
 from typing import Iterator, Any
 
-from google.auth import default
-
 import vertexai
 from vertexai.language_models import TextGenerationModel
 from vertexai.generative_models import GenerativeModel, Part
@@ -12,8 +10,6 @@ from vertexai.generative_models import GenerativeModel, Part
 from health_misinfo_shared.prompts import TRAINING_SET_HEALTH_CLAIMS_PROMPT
 from health_misinfo_shared.data_parsing import parse_model_json_output
 
-
-credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
 GCP_LLM_LOCATION = "us-east1"  # NB: Gemini is not available in europe-west2 (yet?)

--- a/src/health_misinfo_shared/fine_tuning.py
+++ b/src/health_misinfo_shared/fine_tuning.py
@@ -22,7 +22,6 @@ from health_misinfo_shared.prompts import (
 from health_misinfo_shared import youtube_api
 from health_misinfo_shared.vertex import tidy_response
 
-credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
 GCP_LLM_LOCATION = "us-east4"  # NB: Gemini is not available in europe-west2 (yet?)
@@ -62,6 +61,7 @@ def tuning(
         projects/PROJECT_ID/locations/LOCATION_ID/tensorboards/TENSORBOARD_INSTANCE_ID
         Note that this instance must be in the same region as your tuning job.
     """
+    credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
     vertexai.init(
         project=GCP_PROJECT_ID, location=GCP_LLM_LOCATION, credentials=credentials
     )


### PR DESCRIPTION
Fixes #133.

This removes several calls to `google.auth.default()` because I think they’re unused. In fine_tuning.py, it moves the call to `google.auth.default()` inside a function.

This does mean we could end up making repeated calls to `google.auth.default()`, so we could optionally cache the result? But I don’t know if that’s necessary.