### PR TITLE
feat: parse output jsons using existing function

### DIFF
--- a/src/health_misinfo_shared/data_parsing.py
+++ b/src/health_misinfo_shared/data_parsing.py
@@ -2,7 +2,15 @@ import re
 import ast
 import json
 from typing import Any
-from health_misinfo_shared.vertex import tidy_response
+
+
+def tidy_response(response_text: str) -> str:
+    """Strip unnecessary head/tail of response string"""
+    # TODO: Maybe investigate this library instead: https://github.com/noamgat/lm-format-enforcer
+    response_text = response_text.strip(" `'\".")
+    if response_text.startswith("json"):
+        response_text = response_text[5:]
+    return response_text
 
 
 def parse_json_string(json_string: str) -> dict[str, Any] | None:

--- a/src/health_misinfo_shared/data_parsing.py
+++ b/src/health_misinfo_shared/data_parsing.py
@@ -2,6 +2,7 @@ import re
 import ast
 import json
 from typing import Any
+from health_misinfo_shared.vertex import tidy_response
 
 
 def parse_json_string(json_string: str) -> dict[str, Any] | None:
@@ -16,6 +17,7 @@ def parse_json_string(json_string: str) -> dict[str, Any] | None:
 
 def parse_model_json_output(model_output: str) -> list[dict[str, str]]:
     original_output = model_output
+    model_output = tidy_response(model_output)
     model_output = model_output.strip()
     # model_output = re.sub(r"```", "", model_output.strip()).rstrip("\n").lstrip("json")
     try:

--- a/src/health_misinfo_shared/data_parsing.py
+++ b/src/health_misinfo_shared/data_parsing.py
@@ -6,7 +6,7 @@ from typing import Any
 
 def parse_json_string(json_string: str) -> dict[str, Any] | None:
     try:
-        return json.loads(json_string)
+        return json.loads(json_string, strict=False)
     except json.JSONDecodeError:
         try:
             return ast.literal_eval(json_string)

--- a/src/health_misinfo_shared/fine_tuning.py
+++ b/src/health_misinfo_shared/fine_tuning.py
@@ -20,7 +20,6 @@ from health_misinfo_shared.prompts import (
     HEALTH_INFER_MULTI_LABEL_PROMPT,
 )
 from health_misinfo_shared import youtube_api
-from health_misinfo_shared.vertex import tidy_response
 from health_misinfo_shared.data_parsing import parse_model_json_output
 from health_misinfo_shared.label_scoring import get_claim_summary
 
@@ -322,7 +321,6 @@ def get_video_responses(
                 if len(str(candidate.text)) > 0:
                     # print(candidate.safety_attributes)
                     json_text = candidate.text
-                    json_text = tidy_response(json_text)
                     formatted_response = {
                         "response": parse_model_json_output(json_text),
                         "chunk": chunk,

--- a/src/health_misinfo_shared/fine_tuning.py
+++ b/src/health_misinfo_shared/fine_tuning.py
@@ -324,7 +324,7 @@ def get_video_responses(
                     json_text = candidate.text
                     json_text = tidy_response(json_text)
                     formatted_response = {
-                        "response": json.loads(json_text),
+                        "response": parse_model_json_output(json_text),
                         "chunk": chunk,
                         # "safety": candidate.safety_attributes,
                     }

--- a/src/health_misinfo_shared/vertex.py
+++ b/src/health_misinfo_shared/vertex.py
@@ -9,18 +9,10 @@ from vertexai.preview.generative_models import GenerativeModel
 import vertexai.preview.generative_models as generative_models
 from health_misinfo_shared import youtube_api
 from health_misinfo_shared.prompts import HEALTH_CLAIM_PROMPT, HEALTH_HARM_PROMPT
+from health_misinfo_shared.data_parsing import tidy_response
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
 GCP_LOCATION = "us-east4"  # NB: Gemini is not available in europe-west2 (yet?)
-
-
-def tidy_response(response_text: str) -> str:
-    """Strip unnecessary head/tail of response string"""
-    # TODO: Maybe investigate this library instead: https://github.com/noamgat/lm-format-enforcer
-    response_text = response_text.strip(" `'\".")
-    if response_text.startswith("json"):
-        response_text = response_text[5:]
-    return response_text
 
 
 def generate_reponse(transcript: str) -> list[dict]:


### PR DESCRIPTION
Fixes #138.

Replaces `json.loads` with a written function which is better at handling errors in the LLM output.

-----------------

## Pull request checklist

- [x] I have linked my PR to an issue
- [x] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [x] My branch is up-to-date with `main`
- [ ] Where appropriate, I have added or updated tests
- [ ] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
