### PR TITLE
140 add format checker

### DIFF
--- a/src/health_misinfo_shared/claim_format_checker.py
+++ b/src/health_misinfo_shared/claim_format_checker.py
@@ -1,0 +1,37 @@
+from pydantic import BaseModel, ValidationError
+
+
+class LabelsModel(BaseModel):
+    understandability: str
+    type_of_claim: str
+    type_of_medical_claim: str
+    support: str
+    harm: str
+
+
+class ClaimModel(BaseModel):
+    claim: str
+    original_text: str
+    labels: LabelsModel
+
+
+def assert_output_json_format(output: dict) -> bool:
+    try:
+        ClaimModel(**output)
+    except ValidationError:
+        print(output)
+        return False
+    return True
+
+
+def insert_missing_key_as_null(output: dict) -> dict:
+    # fill in data if it is missing
+    if "original_text" not in output.keys():
+        output["original_text"] = "not found"
+    labels = output.get("labels", {})
+    # missing labels will be filled in as blank
+    for k in list(LabelsModel.model_fields):
+        if k not in labels.keys():
+            labels[k] = ""
+    output["labels"] = labels
+    return output

--- a/src/health_misinfo_shared/fine_tuning.py
+++ b/src/health_misinfo_shared/fine_tuning.py
@@ -25,8 +25,6 @@ from health_misinfo_shared.label_scoring import get_claim_summary
 from health_misinfo_shared.claim_format_checker import (
     assert_output_json_format,
     insert_missing_key_as_null,
-    StrictClaimModel,
-    StrictLabelsModel,
 )
 
 

--- a/src/health_misinfo_shared/fine_tuning.py
+++ b/src/health_misinfo_shared/fine_tuning.py
@@ -336,6 +336,7 @@ def get_video_responses(
                 all_successes = all([all(cands) for cands in candidate_successes])
             except Exception as e:
                 print("*** problem handling output? *** ", e)
+                all_successes = False
             if all_successes == False:
                 continue
             if all_successes == True:

--- a/src/health_misinfo_shared/fine_tuning.py
+++ b/src/health_misinfo_shared/fine_tuning.py
@@ -315,7 +315,9 @@ def get_video_responses(
         success = False
         while attempts < 3 and success == False:
             if len(in_context_examples) == 0:
-                response = model.predict(prompt, **parameters)
+                response = model.predict(
+                    prompt, **parameters, safety_settings=safety_settings
+                )
             else:
                 response = model.generate_content(
                     [prompt],

--- a/tests/health_misinfo_shared/test_claim_formatting.py
+++ b/tests/health_misinfo_shared/test_claim_formatting.py
@@ -140,7 +140,7 @@ def test_assert_output_json_format(output, expected_bool):
                     "harm": "",
                 },
             },
-            id="one label missing",
+            id="all labels missing",
         ),
     ],
 )

--- a/tests/health_misinfo_shared/test_claim_formatting.py
+++ b/tests/health_misinfo_shared/test_claim_formatting.py
@@ -1,0 +1,148 @@
+import pytest
+from pytest import mark, param
+
+from health_misinfo_shared.claim_format_checker import (
+    assert_output_json_format,
+    insert_missing_key_as_null,
+)
+
+
+@mark.parametrize(
+    "output, expected_bool",
+    [
+        param(
+            {
+                "claim": "apples help you levitate",
+                "original_text": "eating an apple regularly will allow you to float away",
+                "labels": {
+                    "understandability": "loud and clear",
+                    "type_of_claim": "a bad one",
+                    "type_of_medical_claim": "a serious one",
+                    "support": "none at all",
+                    "harm": "too much",
+                },
+            },
+            True,
+            id="correctly formatted",
+        ),
+        param(
+            {
+                "original_text": "eating an apple regularly will allow you to float away",
+                "labels": {
+                    "understandability": "loud and clear",
+                    "type_of_claim": "a bad one",
+                    "type_of_medical_claim": "a serious one",
+                    "support": "none at all",
+                    "harm": "too much",
+                },
+            },
+            False,
+            id="missing claim",
+        ),
+        param(
+            {
+                "claim": "apples help you levitate",
+                "labels": {
+                    "understandability": "loud and clear",
+                    "type_of_claim": "a bad one",
+                    "type_of_medical_claim": "a serious one",
+                    "support": "none at all",
+                    "harm": "too much",
+                },
+            },
+            False,
+            id="missing original_text",
+        ),
+        param(
+            {
+                "claim": "apples help you levitate",
+                "original_text": "eating an apple regularly will allow you to float away",
+                "labels": {
+                    "understandability": "loud and clear",
+                    "type_of_medical_claim": "a serious one",
+                    "support": "none at all",
+                    "harm": "too much",
+                },
+            },
+            False,
+            id="missing a label",
+        ),
+    ],
+)
+def test_assert_output_json_format(output, expected_bool):
+    assert assert_output_json_format(output) == expected_bool
+
+
+@mark.parametrize(
+    "output, expected_amended",
+    [
+        param(
+            {
+                "claim": "apples help you levitate",
+                "labels": {
+                    "understandability": "loud and clear",
+                    "type_of_claim": "a bad one",
+                    "type_of_medical_claim": "a serious one",
+                    "support": "none at all",
+                    "harm": "too much",
+                },
+            },
+            {
+                "claim": "apples help you levitate",
+                "original_text": "not found",
+                "labels": {
+                    "understandability": "loud and clear",
+                    "type_of_claim": "a bad one",
+                    "type_of_medical_claim": "a serious one",
+                    "support": "none at all",
+                    "harm": "too much",
+                },
+            },
+            id="original_text missing",
+        ),
+        param(
+            {
+                "claim": "apples help you levitate",
+                "original_text": "eating an apple regularly will allow you to float away",
+                "labels": {
+                    "understandability": "loud and clear",
+                    "type_of_claim": "a bad one",
+                    "support": "none at all",
+                    "harm": "too much",
+                },
+            },
+            {
+                "claim": "apples help you levitate",
+                "original_text": "eating an apple regularly will allow you to float away",
+                "labels": {
+                    "understandability": "loud and clear",
+                    "type_of_claim": "a bad one",
+                    "type_of_medical_claim": "",
+                    "support": "none at all",
+                    "harm": "too much",
+                },
+            },
+            id="one label missing",
+        ),
+        param(
+            {
+                "claim": "apples help you levitate",
+                "original_text": "eating an apple regularly will allow you to float away",
+            },
+            {
+                "claim": "apples help you levitate",
+                "original_text": "eating an apple regularly will allow you to float away",
+                "labels": {
+                    "understandability": "",
+                    "type_of_claim": "",
+                    "type_of_medical_claim": "",
+                    "support": "",
+                    "harm": "",
+                },
+            },
+            id="one label missing",
+        ),
+    ],
+)
+def test_insert_missing_value(output, expected_amended):
+    assert insert_missing_key_as_null(output) == expected_amended


### PR DESCRIPTION
Fixes #141 .

Checks LLM response JSONs for correct keys. If validation fails, it will try again twice more, and on the third failure will insert dummy values and move on.

-----------------

## Pull request checklist

- [x] I have linked my PR to an issue
- [x] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [x] My branch is up-to-date with `main`
- [x] Where appropriate, I have added or updated tests
- [ ] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
