### PR TITLE
feat: add summary to LLM output in evaluation

### DIFF
--- a/evaluation/comparing_prompt_with_and_without_context.py
+++ b/evaluation/comparing_prompt_with_and_without_context.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from health_misinfo_shared.prompts import HEALTH_INFER_MULTI_LABEL_PROMPT
 from health_misinfo_shared.fine_tuning import construct_in_context_examples
-
+from health_misinfo_shared.label_scoring import get_claim_summary
 
 in_context_examples, eval_examples = construct_in_context_examples(
     [
@@ -35,7 +35,7 @@ def make_prompts_files():
 
 
 def make_tests_file():
-    training_data_file = "data/test_eval_data_labelled_by_ed.csv"
+    training_data_file = "data/full_in_context_labelled_data.csv"
     training_data = pd.read_csv(training_data_file)
     training_data.fillna("", inplace=True)
 
@@ -54,7 +54,7 @@ def make_tests_file():
                             "type_of_medical_claim": row["type_of_medical_claim"],
                             "support": row["support"],
                             "harm": row["harm"],
-                            "summary": row["summary"],
+                            "summary": get_claim_summary(row),
                         },
                     }
                     for idx, row in sub_df.iterrows()

--- a/evaluation/evaluation.py
+++ b/evaluation/evaluation.py
@@ -153,10 +153,12 @@ def call_api(
     try:
         output: str = run_prompt(model, prompt)
         output_dict = json.loads(output)
-        for i, o in enumerate(output):
+        for i, o in enumerate(output_dict):
             o["labels"]["summary"] = get_claim_summary(o.get("labels", {}))
             output_dict[i] = o
-        response = ProviderResponse(output=output_dict, error=None, tokenUsage=None)
+        response = ProviderResponse(
+            output=json.dumps(output_dict), error=None, tokenUsage=None
+        )
     except Exception as e:
         response = ProviderResponse(output=None, error=repr(e), tokenUsage=None)
 

--- a/evaluation/evaluation.py
+++ b/evaluation/evaluation.py
@@ -11,6 +11,7 @@ import vertexai.preview.generative_models as generative_models
 from vertexai.generative_models import GenerativeModel
 
 from health_misinfo_shared.data_parsing import parse_model_json_output
+from health_misinfo_shared.label_scoring import get_claim_summary
 
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
@@ -151,7 +152,11 @@ def call_api(
 
     try:
         output: str = run_prompt(model, prompt)
-        response = ProviderResponse(output=output, error=None, tokenUsage=None)
+        output_dict = json.loads(output)
+        for i, o in enumerate(output):
+            o["labels"]["summary"] = get_claim_summary(o.get("labels", {}))
+            output_dict[i] = o
+        response = ProviderResponse(output=output_dict, error=None, tokenUsage=None)
     except Exception as e:
         response = ProviderResponse(output=None, error=repr(e), tokenUsage=None)
 

--- a/src/health_misinfo_shared/fine_tuning.py
+++ b/src/health_misinfo_shared/fine_tuning.py
@@ -194,8 +194,11 @@ def make_training_set_multi_label(
     training_data_final = []
     for fn in annotated_files:
         training_data = pd.read_csv(fn)
-        summaries = list(training_data["summary"])
-        training_data = training_data.drop(columns="summary")
+        try:
+            summaries = list(training_data["summary"])
+            training_data = training_data.drop(columns="summary")
+        except KeyError:
+            continue
         training_data.columns = [
             "output_text",
             "input_text",

--- a/src/health_misinfo_shared/fine_tuning.py
+++ b/src/health_misinfo_shared/fine_tuning.py
@@ -194,11 +194,6 @@ def make_training_set_multi_label(
     training_data_final = []
     for fn in annotated_files:
         training_data = pd.read_csv(fn)
-        try:
-            summaries = list(training_data["summary"])
-            training_data = training_data.drop(columns="summary")
-        except KeyError:
-            continue
         training_data.columns = [
             "output_text",
             "input_text",


### PR DESCRIPTION
Fixes #154.

Updates broken promptfoo evaluation to support summary scoring with new functions, now that the LLM does not return summaries.

-----------------

## Pull request checklist

- [x] I have linked my PR to an issue
- [x] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [x] My branch is up-to-date with `main`
- [ ] Where appropriate, I have added or updated tests
- [ ] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
