### PR TITLE
fix: check dataframe columns

### DIFF
--- a/src/health_misinfo_shared/fine_tuning.py
+++ b/src/health_misinfo_shared/fine_tuning.py
@@ -194,6 +194,8 @@ def make_training_set_multi_label(
     training_data_final = []
     for fn in annotated_files:
         training_data = pd.read_csv(fn)
+        if "summary" in training_data.columns:
+            training_data = training_data.drop(columns="summary")
         training_data.columns = [
             "output_text",
             "input_text",


### PR DESCRIPTION
Fixes #157.

A dataframe in `fine_tuning` had inconsistent columns which changed depending on how Raphael was run. Now checking if the offending column exists.

-----------------

## Pull request checklist

- [x] I have linked my PR to an issue
- [x] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [x] My branch is up-to-date with `main`
- [ ] Where appropriate, I have added or updated tests
- [ ] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
