### PR TITLE
feat: updated gemini 1.5 to 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,6 @@ When using above calls on the live demo version, the user/password specified by 
 For building a set of labelled data, we want to get health claims, without all the other stuff we're predicting.
 The `find_claims_within_captions.py` script takes our downloaded YouTube captions and asks Gemini to find all the claims contained within.
 
-> Note on Gemini 1.5: to use this version you have to specify `gemini-1.5-pro-preview-0409` rather than just `gemini-1.5-pro` like you would for 1.0.
-
 ## Writing new prompts
 
 We introduce all prompts with a persona, outlining that the model will be acting as a specialist health fact-checker. If new prompts are written, ensure the following passage is added to the front:

--- a/dev/multimodal/gemini.py
+++ b/dev/multimodal/gemini.py
@@ -23,8 +23,8 @@ VIDEO_SAFETY_SETTINGS = {
 
 
 class GeminiModel:
-    DEFAULT_MODEL = "gemini-1.5-flash-001"
-    DEFAULT_LOCATION = "europe-west2"  # "us-central1" if this has issues...
+    DEFAULT_MODEL = "gemini-2.0-flash-lite"
+    DEFAULT_LOCATION = "europe-west4"
 
     def __init__(
         self,

--- a/dev/prompt_evaluation/ed_autosxs_tests.py
+++ b/dev/prompt_evaluation/ed_autosxs_tests.py
@@ -5,8 +5,8 @@ from google.cloud import aiplatform
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
 GCP_PROJECT_NUMBER = 1447178727
-GCP_LLM_LOCATION = "europe-west4"  # NB: Gemini is not available in europe-west2 (yet?)
-CURRENT_MODEL = "gemini-1.0-pro"
+GCP_LLM_LOCATION = "europe-west4"
+CURRENT_MODEL = "gemini-2.0-flash-lite"
 
 BUCKET_FOLDER = "gs://fullfact-raphael-eval"
 EVALUATION_DATASET = os.path.join(BUCKET_FOLDER, "autosxs_eval.jsonl")

--- a/dev/prompt_evaluation/ed_promptfoo_tests.py
+++ b/dev/prompt_evaluation/ed_promptfoo_tests.py
@@ -7,8 +7,8 @@ from vertexai.generative_models import GenerativeModel
 
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
-GCP_LLM_LOCATION = "us-east1"  # NB: Gemini is not available in europe-west2 (yet?)
-CURRENT_MODEL = "gemini-1.0-pro"
+GCP_LLM_LOCATION = "europe-west4"
+CURRENT_MODEL = "gemini-2.0-flash-lite"
 
 
 class ProcessingException(Exception):

--- a/src/health_misinfo_shared/find_claims_within_captions.py
+++ b/src/health_misinfo_shared/find_claims_within_captions.py
@@ -10,7 +10,7 @@ from health_misinfo_shared.data_parsing import parse_model_json_output
 from health_misinfo_shared.prompts import TRAINING_SET_HEALTH_CLAIMS_PROMPT
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
-GCP_LLM_LOCATION = "us-east1"  # NB: Gemini is not available in europe-west2 (yet?)
+GCP_LLM_LOCATION = "us-east1"
 
 MODEL_PER_MINUTE_QUOTA = {
     "gemini-1.5-pro-preview-0409": 5,

--- a/src/health_misinfo_shared/find_claims_within_captions.py
+++ b/src/health_misinfo_shared/find_claims_within_captions.py
@@ -12,6 +12,18 @@ from health_misinfo_shared.prompts import TRAINING_SET_HEALTH_CLAIMS_PROMPT
 GCP_PROJECT_ID = "exemplary-cycle-195718"
 GCP_LLM_LOCATION = "us-east1"
 
+#######################################
+# ATTENTION
+#######################################
+# This script was written while we used
+# Gemini 1 + 1.5.
+# It has not been updated for 2.0, because
+# these quotas would all need working out again.
+#
+# If you want to run this again, please update
+# everything for gemini-flash-2.0.
+#######################################
+
 MODEL_PER_MINUTE_QUOTA = {
     "gemini-1.5-pro-preview-0409": 5,
     "gemini-1.0-pro": 300,

--- a/src/health_misinfo_shared/fine_tuning.py
+++ b/src/health_misinfo_shared/fine_tuning.py
@@ -26,8 +26,8 @@ from health_misinfo_shared.prompts import (
 )
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
-GCP_LLM_LOCATION = "europe-west4"  # NB: Gemini is not available in europe-west2 (yet?)
-GCP_TUNED_MODEL_LOCATION = "europe-west4"  # where we do fine tuning/model storage
+GCP_LLM_LOCATION = "europe-west4"
+GCP_TUNED_MODEL_LOCATION = "europe-west4"
 CHECKWORTHY_EXPLANATIONS = ["high harm", "citation", "low harm"]
 UNCHECKWORTHY_EXPLANATIONS = ["nothing to check", "hedged claim"]
 VALID_EXPLANATIONS = CHECKWORTHY_EXPLANATIONS + UNCHECKWORTHY_EXPLANATIONS
@@ -450,10 +450,8 @@ def infer_transcript_claims(transcript: list[dict]) -> Iterable[dict[str, Any]]:
     vertexai.init(project=GCP_PROJECT_ID, location=GCP_TUNED_MODEL_LOCATION)
 
     chunks = youtube_api.form_chunks(transcript)
-    model = GenerativeModel("gemini-1.5-pro-preview-0514")
-    annotated_data_files = [
-        (Path(__file__).parent / "full_in_context_labelled_data.csv")
-    ]
+    model = GenerativeModel("gemini-2.0-flash-lite")
+    annotated_data_files = [Path(__file__).parent / "full_in_context_labelled_data.csv"]
     in_context_examples, empty_hold_out_set = construct_in_context_examples(
         annotated_data_files, split_frac=1.0
     )
@@ -525,9 +523,7 @@ if __name__ == "__main__":
         tuning("cj_tuned_multi_label_0", _training_data)
 
     if mode == "in_context":
-        model = GenerativeModel(
-            "gemini-1.5-pro-preview-0514"
-        )  # or is it 0514 (May 15th update)
+        model = GenerativeModel("gemini-2.0-flash-lite")
         annotated_data_files = [
             (Path(__file__).parent / "full_in_context_labelled_data.csv")
         ]

--- a/src/health_misinfo_shared/fine_tuning.py
+++ b/src/health_misinfo_shared/fine_tuning.py
@@ -466,7 +466,7 @@ def infer_transcript_claims(transcript: list[dict]) -> Iterable[dict[str, Any]]:
 
 
 def infer_multimodal_claims(
-    bucket_name: str, video_path: str, model_name: str = "gemini-1.5-flash-001"
+    bucket_name: str, video_path: str, model_name: str = "gemini-2.0-flash-lite"
 ) -> Iterable[dict[str, Any]]:
     vertexai.init(project=GCP_PROJECT_ID, location=GCP_LLM_LOCATION)
     model = GenerativeModel(model_name=model_name)

--- a/src/health_misinfo_shared/vertex.py
+++ b/src/health_misinfo_shared/vertex.py
@@ -14,7 +14,7 @@ from health_misinfo_shared.data_parsing import parse_model_json_output
 from health_misinfo_shared.prompts import HEALTH_CLAIM_PROMPT
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
-GCP_LOCATION = "us-east4"  # NB: Gemini is not available in europe-west2 (yet?)
+GCP_LOCATION = "europe-west4"  # NB: Gemini is not available in europe-west2 (yet?)
 
 
 def generate_reponse(transcript: str) -> list[dict]:

--- a/src/health_misinfo_shared/vertex.py
+++ b/src/health_misinfo_shared/vertex.py
@@ -14,7 +14,7 @@ from health_misinfo_shared.data_parsing import parse_model_json_output
 from health_misinfo_shared.prompts import HEALTH_CLAIM_PROMPT
 
 GCP_PROJECT_ID = "exemplary-cycle-195718"
-GCP_LOCATION = "europe-west4"  # NB: Gemini is not available in europe-west2 (yet?)
+GCP_LOCATION = "europe-west4"
 
 
 def generate_reponse(transcript: str) -> list[dict]:

--- a/src/raphael_backend_flask/db.py
+++ b/src/raphael_backend_flask/db.py
@@ -86,7 +86,7 @@ def create_multimodal_claim_extraction_run(
         (
             user_id,
             video_id,
-            "gemini-1.5-flash-001",
+            "gemini-2.0-flash-lite",
             "processing",
         ),
     )


### PR DESCRIPTION
Fixes [1033](https://linear.app/fullfact/issue/AI-1033/upgrade-raphael-demo).

Updates gemini from version 1.5 flash to 2.0 flash.

I can't see any more (important) mentions of Gemini 1.5 anymore. This code is a bit of a monster though, so there are a couple of non-production scripts which I've left untouched.

It seems to work okay when I run it locally.

The results are different when I run the same video to 1.5 and 2.0, but that's probably to be expected. It didn't seem worse in any obvious way.

-----------------

## Pull request checklist

- [ ] I have linked my PR to an issue
- [ ] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [ ] My branch is up-to-date with `main`
- [ ] Where appropriate, I have added or updated tests
- [ ] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
